### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/mycloudpath/083d200b-222a-427d-be9e-f129906c56c5/d0e5bc62-5cbf-43a0-80f8-aa690d5ada05/_apis/work/boardbadge/d4da5f19-7574-43cd-872a-6147394d4721)](https://dev.azure.com/mycloudpath/083d200b-222a-427d-be9e-f129906c56c5/_boards/board/t/d0e5bc62-5cbf-43a0-80f8-aa690d5ada05/Microsoft.RequirementCategory)
 # IaCLab
 Learn ARM IaC


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#69](https://dev.azure.com/mycloudpath/083d200b-222a-427d-be9e-f129906c56c5/_workitems/edit/69). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.